### PR TITLE
FIX: import path was wrong in 5.2.1 section

### DIFF
--- a/_web/vuejs-miseenoeuvre-part2.md
+++ b/_web/vuejs-miseenoeuvre-part2.md
@@ -1097,7 +1097,7 @@ Nous prendrons comme exemple le composant *CreatePolldle* défini dans le fichie
 import { ref, reactive } from 'vue'
 
 // Import CreatePolldleOption component
-import CreatePolldleOption from "./components/CreatePolldleOption.vue";
+import CreatePolldleOption from "./CreatePolldleOption.vue";
 ...
 </script>
 <template>


### PR DESCRIPTION
CreatePolldle.vue is in the same directory as CreatePolldleOption.vue, so adding ./components/ leads to a non existent path.